### PR TITLE
chore: fix github page workflow permission

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,8 @@
-name: Deploy to GitHub Pages
+name: GitHub Pages
+
+# Allow the workflow's GITHUB_TOKEN to push commit(s) (required by peaceiris/actions-gh-pages)
+permissions:
+  contents: write
 
 # Run after the Unit Test workflow completes successfully on the `main` branch.
 on:


### PR DESCRIPTION
* Added `contents: write` permission to the workflow to allow pushing commits during deployment. (.github/workflows/gh-pages.yml)