### PR TITLE
fix: fix production-only missed onDoubleClick by remounting mesh

### DIFF
--- a/src/components/editor/geometry-model.tsx
+++ b/src/components/editor/geometry-model.tsx
@@ -123,6 +123,7 @@ export const GeometryModel = ({
     <Bvh name="bvh-group">
       <mesh
         name="inputMesh"
+        key={editorState}
         ref={meshRef}
         onDoubleClick={
           editorState === 'landmarks' ? handleMeshClick : undefined


### PR DESCRIPTION
* Added the `key={editorState}` prop to the `mesh` element in `geometry-model.tsx`, ensuring that the mesh is remounted when the editor state changes. 

The issue reproduced only in production builds where optimized timing meant the R3F event binding could be missed during editorState toggles. This change forces a remount so the handler is always registeredtached reliably in built/preview environments.