### PR TITLE
Fix stale raycasts by running recenter/camera logic in useLayoutEffect

### DIFF
--- a/src/components/editor/controls/transform-controls.tsx
+++ b/src/components/editor/controls/transform-controls.tsx
@@ -80,6 +80,9 @@ export const TransformControls = ({
         </CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col p-4 overflow-hidden">
+        <div className="mb-4 text-sm text-muted-foreground text-center font-medium">
+          Use right-click to switch the gizmo mode (Translate or Rotate).
+        </div>
         <ScrollArea className="flex-1 min-h-24 gap-2" type="auto">
           <div className="flex flex-col gap-2">
             <Card>

--- a/src/components/editor/geometry-model.tsx
+++ b/src/components/editor/geometry-model.tsx
@@ -1,6 +1,6 @@
 import { Bvh } from '@react-three/drei'
 import { useLoader, useThree, type ThreeEvent } from '@react-three/fiber'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import {
   DoubleSide,
   type Mesh,
@@ -123,7 +123,6 @@ export const GeometryModel = ({
     <Bvh name="bvh-group">
       <mesh
         name="inputMesh"
-        key={editorState}
         ref={meshRef}
         onDoubleClick={
           editorState === 'landmarks' ? handleMeshClick : undefined
@@ -145,7 +144,7 @@ export const GeometryModel = ({
     </Bvh>
   )
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (meshRef.current && !initialCameraSetupRef.current) {
       meshRef.current.geometry.center()
 


### PR DESCRIPTION
Directly mutating mesh properties like position or geometry after mount causes React Three Fiber's internal event system and raycasting to become out of sync, preventing pointer events from firing until a remount or subsequent render occurs. The problem occurs in production builds due to React's optimized reconciliation behavior, while it is masked in development.

* Changed from `useEffect` to `useLayoutEffect` for the initial camera setup in `GeometryModel`, which can help ensure geometry centering occurs before browser painting for smoother visuals.

**Editor usability improvements:**

* Added a tip to the `TransformControls` panel instructing users to use right-click to switch between gizmo modes (Translate or Rotate).

